### PR TITLE
Add commands & refactor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         }
     ],
     "require": {
+        "php": ">=7.1",
         "illuminate/support": "^5.0",
         "illuminate/console": "^5.0",
         "nikic/php-parser": "^3.1 | ^4.0"

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,10 @@
         {
             "name": "James Judd",
             "email": "james.judd@netsells.co.uk"
+        },
+        {
+            "name": "Karl Roberts",
+            "email": "karlos545@hotmail.com"
         }
     ],
     "require": {

--- a/src/FindInvalid.php
+++ b/src/FindInvalid.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Juddling\RouteChecker;
+
+use Illuminate\Support\Collection;
+use Illuminate\Routing\Route;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\ParserFactory;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class FindInvalid
+{
+    protected $parser;
+    /** @var Collection */
+    protected $routeCalls;
+
+    protected $nameOfArgument = 'Parameter';
+
+    public function __construct()
+    {
+        $this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        $this->results = new Collection;
+    }
+
+    abstract protected function check(string $argument);
+    abstract protected function getFunctionName();
+
+	public function findFunctionCalls($file)
+    {
+        $code = file_get_contents($file);
+
+        $traverser = new NodeTraverser;
+        $visitor = new FindingVisitor(function (Node $node) use ($file) {
+            if ($node instanceof Node\Expr\FuncCall) {
+                if ($node->name instanceof Node\Name && $node->name->toString() === $this->getFunctionName()) {
+                    $firstArgument = $node->args[0];
+
+                    if ($firstArgument->value instanceof \PhpParser\Node\Scalar\String_) {
+                        // value of first argument is route name
+                        $stringScalar = $firstArgument->value;
+                        $firstArgument = $stringScalar->value;
+
+                        $this->results->push([
+                            'name' => $firstArgument,
+                            'valid' => $this->check($firstArgument),
+                            'file' => $file
+                        ]);
+
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        });
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($this->parser->parse($code));
+        return $visitor->getFoundNodes();
+    }
+
+	public function renderTable(OutputInterface $output)
+    {
+        $table = new \Symfony\Component\Console\Helper\Table($output);
+        $table->setHeaders([$this->nameOfArgument, 'Valid', 'File']);
+
+        $table->addRows($this->results->sortBy('valid')->map(function ($call) {
+            $call['valid'] = $call['valid'] ? '✅' : '❌';
+            return $call;
+        })->toArray());
+
+        $table->setStyle('borderless');
+        $table->render();
+    }
+}

--- a/src/FindInvalidRouteCalls.php
+++ b/src/FindInvalidRouteCalls.php
@@ -7,27 +7,27 @@ use Illuminate\Support\Collection;
 
 class FindInvalidRouteCalls extends FindInvalid
 {
-	/** @var Collection */
-	protected $routeNames;
-	protected $nameOfArgument = 'Route Names';
+    /** @var Collection */
+    protected $routeNames;
+    protected $nameOfArgument = 'Route Names';
 
-	public function __construct()
-	{
-		$this->routeNames = collect(\Route::getRoutes())
-			->map(function (Route $route) {
-				return $route->getName();
-			})->filter();
+    public function __construct()
+    {
+        $this->routeNames = collect(\Route::getRoutes())
+            ->map(function (Route $route) {
+                return $route->getName();
+            })->filter();
 
-		parent::__construct();
-	}
+        parent::__construct();
+    }
 
-	protected function getFunctionName()
-	{
-		return 'route';
-	}
+    protected function getFunctionName()
+    {
+        return 'route';
+    }
 
-	protected function check(string $routeName): bool
-	{
-		return $this->routeNames->contains($routeName);
-	}
+    protected function check(string $routeName): bool
+    {
+        return $this->routeNames->contains($routeName);
+    }
 }

--- a/src/FindInvalidRouteCalls.php
+++ b/src/FindInvalidRouteCalls.php
@@ -4,35 +4,31 @@ namespace Juddling\RouteChecker;
 
 use Illuminate\Support\Collection;
 use Illuminate\Routing\Route;
-use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\ParserFactory;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class FindInvalidRouteCalls extends FindInvalid
 {
-	/** @var Collection */
-	protected $routeNames;
-	protected $nameOfArgument = 'Route Names';
+    /** @var Collection */
+    protected $routeNames;
+    protected $nameOfArgument = 'Route Names';
 
 
-	protected function getFunctionName()
-	{
-		return 'route';
-	}
+    protected function getFunctionName()
+    {
+        return 'route';
+    }
 
-	protected function check(string $routeName): bool
-	{
-		if ($this->routeNames) {
-			return $this->routeNames->contains($routeName);
-		}
+    protected function check(string $routeName): bool
+    {
+        if ($this->routeNames) {
+            return $this->routeNames->contains($routeName);
+        }
 
-		// set the routes
-		$this->routeNames = collect(\Route::getRoutes())->map(function (Route $route) {
-			return $route->getName();
-		})->filter();
+        // set the routes
+        $this->routeNames = collect(\Route::getRoutes())->map(function (Route $route) {
+            return $route->getName();
+        })->filter();
 
-		// now try this function again
-		return $this->check($routeName);
-	}
+        // now try this function again
+        return $this->check($routeName);
+    }
 }

--- a/src/FindInvalidRouteCalls.php
+++ b/src/FindInvalidRouteCalls.php
@@ -9,77 +9,30 @@ use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class FindInvalidRouteCalls
+class FindInvalidRouteCalls extends FindInvalid
 {
-    protected $parser;
-    /** @var Collection */
-    protected $routeNames;
-    /** @var Collection */
-    protected $routeCalls;
+	/** @var Collection */
+	protected $routeNames;
+	protected $nameOfArgument = 'Route Names';
 
-    public function __construct()
-    {
-        $this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        $this->routeCalls = new Collection;
-    }
 
-    protected function routeExists($routeName): bool
-    {
-        if ($this->routeNames) {
-            return $this->routeNames->contains($routeName);
-        }
+	protected function getFunctionName()
+	{
+		return 'route';
+	}
 
-        // set the routes
-        $this->routeNames = collect(\Route::getRoutes())->map(function (Route $route) {
-            return $route->getName();
-        })->filter();
+	protected function check(string $routeName): bool
+	{
+		if ($this->routeNames) {
+			return $this->routeNames->contains($routeName);
+		}
 
-        // now try this function again
-        return $this->routeExists($routeName);
-    }
+		// set the routes
+		$this->routeNames = collect(\Route::getRoutes())->map(function (Route $route) {
+			return $route->getName();
+		})->filter();
 
-    public function findRouteFunctionCalls($file)
-    {
-        $code = file_get_contents($file);
-
-        $traverser = new NodeTraverser;
-        $visitor = new FindingVisitor(function (Node $node) use ($file) {
-            if ($node instanceof Node\Expr\FuncCall) {
-                if ($node->name instanceof Node\Name && $node->name->toString() === 'route') {
-                    $firstArgument = $node->args[0];
-
-                    if ($firstArgument->value instanceof \PhpParser\Node\Scalar\String_) {
-                        // value of first argument is route name
-                        $stringScalar = $firstArgument->value;
-                        $routeName = $stringScalar->value;
-
-                        $this->routeCalls->push([
-                            'name' => $routeName,
-                            'valid' => $this->routeExists($routeName),
-                            'file' => $file
-                        ]);
-
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        });
-        $traverser->addVisitor($visitor);
-        $traverser->traverse($this->parser->parse($code));
-        return $visitor->getFoundNodes();
-    }
-
-    public function renderTable(OutputInterface $output)
-    {
-        $table = new \Symfony\Component\Console\Helper\Table($output);
-        $table->setHeaders(['Route Name', 'Valid', 'File']);
-        $table->addRows($this->routeCalls->sortBy('valid')->map(function ($call) {
-            $call['valid'] = $call['valid'] ? '✅' : '❌';
-            return $call;
-        })->toArray());
-        $table->setStyle('borderless');
-        $table->render();
-    }
+		// now try this function again
+		return $this->check($routeName);
+	}
 }

--- a/src/FindInvalidRouteCalls.php
+++ b/src/FindInvalidRouteCalls.php
@@ -15,6 +15,14 @@ class FindInvalidRouteCalls extends FindInvalid
 	protected $routeNames;
 	protected $nameOfArgument = 'Route Names';
 
+	public function __construct()
+	{
+		$this->routeNames = collect(\Route::getRoutes())->map(function (Route $route) {
+			return $route->getName();
+		})->filter();
+
+		parent::__construct();
+	}
 
 	protected function getFunctionName()
 	{
@@ -23,16 +31,6 @@ class FindInvalidRouteCalls extends FindInvalid
 
 	protected function check(string $routeName): bool
 	{
-		if ($this->routeNames) {
-			return $this->routeNames->contains($routeName);
-		}
-
-		// set the routes
-		$this->routeNames = collect(\Route::getRoutes())->map(function (Route $route) {
-			return $route->getName();
-		})->filter();
-
-		// now try this function again
-		return $this->check($routeName);
+		return $this->routeNames->contains($routeName);
 	}
 }

--- a/src/FindInvalidRouteCallsCommand.php
+++ b/src/FindInvalidRouteCallsCommand.php
@@ -9,7 +9,7 @@ use RegexIterator;
 
 class FindInvalidRouteCallsCommand extends Command
 {
-    protected $signature = 'juddling:find-invalid-routes';
+    protected $signature = 'runtime-errors:route-calls';
     protected $description = 'Checks your route calls to see if they map to a registered named route';
     protected $routeCalls;
 

--- a/src/FindInvalidRouteCallsCommand.php
+++ b/src/FindInvalidRouteCallsCommand.php
@@ -38,7 +38,7 @@ class FindInvalidRouteCallsCommand extends Command
     {
         foreach ($this->getAllFilesInDir(getcwd(), 'php') as $file) {
             if (!$this->blacklisted($file)) {
-                $this->routeCalls->findRouteFunctionCalls($file);
+                $this->routeCalls->findFunctionCalls($file);
             }
         }
 

--- a/src/FindInvalidRouteDefinitions.php
+++ b/src/FindInvalidRouteDefinitions.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Juddling\RouteChecker;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+
+class FindInvalidRouteDefinitions extends FindInvalidRouteCalls
+{
+    public function findRouteFunctionCalls($file)
+    {
+        dump($this->parser->parse(file_get_contents($file)));
+
+        $traverser = new NodeTraverser;
+        $visitor = new FindingVisitor(function (Node $node) use ($file) {
+            if ($node instanceof Node\Expr\StaticCall) {
+                if ($node->name instanceof Node\Name && $node->name->toString() === 'route') {
+                    $firstArgument = $node->args[0];
+
+                    if ($firstArgument->value instanceof Node\Scalar\String_) {
+                        // value of first argument is route name
+                        $stringScalar = $firstArgument->value;
+                        $routeName = $stringScalar->value;
+
+                        $this->routeCalls->push([
+                            'name' => $routeName,
+                            'valid' => $this->routeExists($routeName),
+                            'file' => $file
+                        ]);
+
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        });
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($this->parser->parse(file_get_contents($file)));
+
+        return $visitor->getFoundNodes();
+    }
+}

--- a/src/FindInvalidRouteDefinitionsCommand.php
+++ b/src/FindInvalidRouteDefinitionsCommand.php
@@ -7,7 +7,7 @@ use RegexIterator;
 
 class FindInvalidRouteDefinitionsCommand extends FindInvalidRouteCallsCommand
 {
-    protected $signature = 'juddling:route-definitions';
+    protected $signature = 'runtime-errors:route-definitions';
     protected $description = 'Checks your route definitions to see if they point to an existing controller action';
     protected $routeDefinitions;
 

--- a/src/FindInvalidRouteDefinitionsCommand.php
+++ b/src/FindInvalidRouteDefinitionsCommand.php
@@ -21,8 +21,10 @@ class FindInvalidRouteDefinitionsCommand extends FindInvalidRouteCallsCommand
     public function handle()
     {
         foreach ($this->routeFiles() as $file) {
-            $this->routeDefinitions->findRouteFunctionCalls($file);
+            $this->routeDefinitions->findFunctionCalls($file);
         }
+
+        $this->routeDefinitions->renderTable($this->getOutput());
     }
 
     /**

--- a/src/FindInvalidRouteDefinitionsCommand.php
+++ b/src/FindInvalidRouteDefinitionsCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Juddling\RouteChecker;
+
+use DirectoryIterator;
+use RegexIterator;
+
+class FindInvalidRouteDefinitionsCommand extends FindInvalidRouteCallsCommand
+{
+    protected $signature = 'juddling:route-definitions';
+    protected $description = 'Checks your route definitions to see if they point to an existing controller action';
+    protected $routeDefinitions;
+
+    public function __construct(FindInvalidRouteDefinitions $routeDefinitions)
+    {
+        $this->routeDefinitions = $routeDefinitions;
+
+        parent::__construct(new FindInvalidRouteCalls());
+    }
+
+    public function handle()
+    {
+        foreach ($this->routeFiles() as $file) {
+            $this->routeDefinitions->findRouteFunctionCalls($file);
+        }
+    }
+
+    /**
+     * Returns the path to all route files, e.g.:
+     * routes/api.php
+     * routes/web.php
+     *
+     * @return \Generator
+     */
+    protected function routeFiles()
+    {
+        $it = new DirectoryIterator(realpath(getcwd()) . '/routes/');
+        $it = new RegexIterator($it, '(\.php$)');
+
+        foreach ($it as $file) {
+            /** @var \SplFileObject $file */
+            $filepath = $file->getRealPath();
+            yield $filepath;
+        }
+    }
+}

--- a/src/FindInvalidViewCalls.php
+++ b/src/FindInvalidViewCalls.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Juddling\RouteChecker;
+
+use Illuminate\Support\Collection;
+use Illuminate\Routing\Route;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\ParserFactory;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FindInvalidRouteCalls extends FindInvalid
+{
+	/** @var Collection */
+	protected $viewPaths;
+	protected $nameOfArgument = 'View Path';
+
+
+	protected function getFunctionName()
+	{
+		return 'view';
+	}
+
+	protected function check(string $viewPath): bool
+	{
+		if ($this->viewPaths) {
+			return $this->viewPaths->contains($viewPath);
+		}
+
+		// Check if the view is present
+
+		// now try this function again
+		return $this->check($viewPath);
+	}
+}

--- a/src/FindInvalidViewCalls.php
+++ b/src/FindInvalidViewCalls.php
@@ -4,17 +4,18 @@ namespace Juddling\RouteChecker;
 
 use Illuminate\Support\Collection;
 use Illuminate\Routing\Route;
+use Illuminate\View\FileViewFinder;
+use InvalidArgumentException;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class FindInvalidRouteCalls extends FindInvalid
+class FindInvalidViewCalls extends FindInvalid
 {
 	/** @var Collection */
 	protected $viewPaths;
 	protected $nameOfArgument = 'View Path';
-
 
 	protected function getFunctionName()
 	{
@@ -23,13 +24,15 @@ class FindInvalidRouteCalls extends FindInvalid
 
 	protected function check(string $viewPath): bool
 	{
-		if ($this->viewPaths) {
-			return $this->viewPaths->contains($viewPath);
+		/** @var FileViewFinder $views */
+		$views = app('view.finder');
+
+		try {
+			$views->find($viewPath);
+		} catch (InvalidArgumentException $e) {
+			return false;
 		}
 
-		// Check if the view is present
-
-		// now try this function again
-		return $this->check($viewPath);
+		return true;
 	}
 }

--- a/src/FindInvalidViewCalls.php
+++ b/src/FindInvalidViewCalls.php
@@ -3,19 +3,23 @@
 namespace Juddling\RouteChecker;
 
 use Illuminate\Support\Collection;
-use Illuminate\Routing\Route;
 use Illuminate\View\FileViewFinder;
 use InvalidArgumentException;
-use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\ParserFactory;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class FindInvalidViewCalls extends FindInvalid
 {
 	/** @var Collection */
 	protected $viewPaths;
+	/** @var string $nameOfArgument */
 	protected $nameOfArgument = 'View Path';
+	/** @var FileViewFinder $views */
+	protected $viewFinder;
+
+	public function __construct()
+	{
+		$this->viewFinder = app('view.finder');
+		parent::__construct();
+	}
 
 	protected function getFunctionName()
 	{
@@ -24,11 +28,8 @@ class FindInvalidViewCalls extends FindInvalid
 
 	protected function check(string $viewPath): bool
 	{
-		/** @var FileViewFinder $views */
-		$views = app('view.finder');
-
 		try {
-			$views->find($viewPath);
+			$this->viewFinder->find($viewPath);
 		} catch (InvalidArgumentException $e) {
 			return false;
 		}

--- a/src/FindInvalidViewCalls.php
+++ b/src/FindInvalidViewCalls.php
@@ -8,32 +8,32 @@ use InvalidArgumentException;
 
 class FindInvalidViewCalls extends FindInvalid
 {
-	/** @var Collection */
-	protected $viewPaths;
-	/** @var string $nameOfArgument */
-	protected $nameOfArgument = 'View Path';
-	/** @var FileViewFinder $views */
-	protected $viewFinder;
+    /** @var Collection */
+    protected $viewPaths;
+    /** @var string $nameOfArgument */
+    protected $nameOfArgument = 'View Path';
+    /** @var FileViewFinder $views */
+    protected $viewFinder;
 
-	public function __construct()
-	{
-		$this->viewFinder = app('view.finder');
-		parent::__construct();
-	}
+    public function __construct()
+    {
+        $this->viewFinder = app('view.finder');
+        parent::__construct();
+    }
 
-	protected function getFunctionName()
-	{
-		return 'view';
-	}
+    protected function getFunctionName()
+    {
+        return 'view';
+    }
 
-	protected function check(string $viewPath): bool
-	{
-		try {
-			$this->viewFinder->find($viewPath);
-		} catch (InvalidArgumentException $e) {
-			return false;
-		}
+    protected function check(string $viewPath): bool
+    {
+        try {
+            $this->viewFinder->find($viewPath);
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 }

--- a/src/FindInvalidViewCallsCommand.php
+++ b/src/FindInvalidViewCallsCommand.php
@@ -9,7 +9,7 @@ use RegexIterator;
 
 class FindInvalidViewCallsCommand extends Command
 {
-    protected $signature = 'juddling:find-invalid-views';
+    protected $signature = 'runtime-errors:view-calls';
     protected $description = 'Checks your view calls to see if they map to a file that exists.';
     protected $routeCalls;
 

--- a/src/FindInvalidViewCallsCommand.php
+++ b/src/FindInvalidViewCallsCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Juddling\RouteChecker;
+
+use Illuminate\Console\Command;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
+
+class FindInvalidViewCallsCommand extends Command
+{
+    protected $signature = 'juddling:find-invalid-views';
+    protected $description = 'Checks your view calls to see if they map to a file that exists.';
+    protected $routeCalls;
+
+    public function __construct(FindInvalidViewCalls $views)
+    {
+        $this->views = $views;
+
+        parent::__construct();
+    }
+
+    private function getAllFilesInDir($directory, $fileExtension)
+    {
+        $directory = realpath($directory);
+        $it = new RecursiveDirectoryIterator($directory);
+        $it = new RecursiveIteratorIterator($it, RecursiveIteratorIterator::LEAVES_ONLY);
+        $it = new RegexIterator($it, '(\.' . preg_quote($fileExtension) . '$)');
+
+        foreach ($it as $file) {
+            /** @var \SplFileObject $file */
+            $filepath = $file->getRealPath();
+            yield $filepath;
+        }
+    }
+
+    public function handle()
+    {
+        foreach ($this->getAllFilesInDir(getcwd(), 'php') as $file) {
+            if (!$this->blacklisted($file)) {
+                $this->views->findFunctionCalls($file);
+            }
+        }
+
+        $this->views->renderTable($this->getOutput());
+    }
+
+    protected function blacklisted($file)
+    {
+        return strpos($file, 'vendor/')
+            || strpos($file, 'storage/framework/views/');
+    }
+}

--- a/src/FindingVisitor.php
+++ b/src/FindingVisitor.php
@@ -6,6 +6,8 @@ use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
 /**
+ * NOTE this class has been copied in from version 4.0 of PHP-Parser
+ *
  * This visitor can be used to find and collect all nodes satisfying some criterion determined by
  * a filter callback.
  */

--- a/src/RouteCheckerServiceProvider.php
+++ b/src/RouteCheckerServiceProvider.php
@@ -10,6 +10,7 @@ class RouteCheckerServiceProvider extends ServiceProvider
     {
         $this->commands([
             FindInvalidRouteCallsCommand::class,
+            FindInvalidViewCallsCommand::class,
             FindInvalidRouteDefinitionsCommand::class,
         ]);
     }

--- a/src/RouteCheckerServiceProvider.php
+++ b/src/RouteCheckerServiceProvider.php
@@ -9,7 +9,8 @@ class RouteCheckerServiceProvider extends ServiceProvider
     public function register()
     {
         $this->commands([
-            FindInvalidRouteCallsCommand::class
+            FindInvalidRouteCallsCommand::class,
+            FindInvalidRouteDefinitionsCommand::class,
         ]);
     }
 }


### PR DESCRIPTION
Adds command to find invalid route definitions - this should later be refactored to use Laravel's `Route::getRoutes()`.

Adds command to find invalid calls to the `view()` helper method.